### PR TITLE
Set httpNumThreads=8 for proxy

### DIFF
--- a/start.py
+++ b/start.py
@@ -143,7 +143,8 @@ def main(args):
     proxy_conf = proxy_node.get_file(PROXY_CONF)
     proxy_properties = PropertiesFile.loads(proxy_conf)
     proxy_properties.update({'zookeeperServers': zk_servers_conf,
-                             'configurationStoreServers': zk_servers_conf})
+                             'configurationStoreServers': zk_servers_conf,
+                             'httpNumThreads': '8'})
     proxy_node.put_file(PROXY_CONF, PropertiesFile.dumps(proxy_properties))
 
     # TLS


### PR DESCRIPTION
This is important for 2.3.2 on certain machines (a.k.a Jenkins) due to

https://github.com/apache/pulsar/issues/4359