### PR TITLE
Add support for Pulsar clusters with JWT authentication

### DIFF
--- a/topology.yaml
+++ b/topology.yaml
@@ -22,6 +22,9 @@ node groups:
         - broker-2
 
 start args:
+    --jwt:
+        action: store_true
+        help: If specified, configure Pulsar for using JWT authentication
     --proxy-node-name:
         default: pulsar
         help: Pulsar proxy node's host name


### PR DESCRIPTION
From Pulsar 2.3.0, authorization through JSON Web tokens is supported. In this PR there are the needed modifications to set up a Pulsar cluster with JWT authentication. You just would need to specify the `--jwt` parameter.

After the cluster is set up, the token could be obtained with the command below:
```
docker exec -it <proxy-container-id> cat /opt/pulsar/jwt.token
```