### PR TITLE
Add packaging module to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@
 # limitations under the License.
 
 javaproperties==0.3.0
+packaging


### PR DESCRIPTION
Recent changes require the use of the packaging module. Adding it to the requirements.txt file.