### PR TITLE
Limit Pulsar memory

### DIFF
--- a/topology.yaml
+++ b/topology.yaml
@@ -37,6 +37,8 @@ start args:
         default: pulsar-cluster
         help: Pulsar cluster name to use
         metavar: name
+    --pulsar-max-memory:
+        help: Pulsar memory to use (use m for MB and g for GB)
     --predictable:
         action: store_true
         help: If specified, attempt to expose container ports to the same port number on the host


### PR DESCRIPTION
This change adds the option to limit the memory usage of Pulsar. 

There may be other more elegant ways to achieve this, such as configuring the environment variable or adding this configuration line to the end of the `pulsar_env.sh` file, however this is the only solution I have found that works for all versions of Pulsar that clusterdock supports.