### PR TITLE
Add openssl.cnf to the repo

### DIFF
--- a/resources/openssl.cnf
+++ b/resources/openssl.cnf
@@ -1,0 +1,152 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+# Configuration file for testing certificate authority.
+# The environment variable, CA_HOME, must be set to point to the directory
+# containing this file before running any openssl commands.
+#
+[ ca ]
+# `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = $ENV::CA_HOME
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+RANDFILE          = $dir/private/.rand
+
+# The root key and root certificate.
+private_key       = $dir/private/ca.key.pem
+certificate       = $dir/certs/ca.cert.pem
+
+# For certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/ca.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 30
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_strict
+
+[ policy_strict ]
+# The root CA should only sign intermediate certificates that match.
+# See the POLICY FORMAT section of `man ca`.
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ policy_loose ]
+# Allow the intermediate CA to sign a more diverse range of certificates.
+# See the POLICY FORMAT section of the `ca` man page.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# Options for the `req` tool (`man req`).
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md          = sha256
+
+# Extension to add when the -x509 option is used.
+x509_extensions     = v3_ca
+
+[ req_distinguished_name ]
+# See <https://en.wikipedia.org/wiki/Certificate_signing_request>.
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address
+
+# Optionally, specify some defaults.
+countryName_default             = US
+stateOrProvinceName_default     = California
+localityName_default            = Palo Alto
+0.organizationName_default      = My company
+organizationalUnitName_default  = IT
+emailAddress_default            =
+
+[ v3_ca ]
+# Extensions for a typical CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+# Extensions for client certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = client, email
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ server_cert ]
+# Extensions for server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ crl_ext ]
+# Extension for CRLs (`man x509v3_config`).
+authorityKeyIdentifier=keyid:always
+
+[ ocsp ]
+# Extension for OCSP signing certificates (`man ocsp`).
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning

--- a/start.py
+++ b/start.py
@@ -47,6 +47,8 @@ TLS_CONF_URL = 'https://raw.githubusercontent.com/apache/pulsar-site/master/site
 TLS_DIR = '{}/pulsar_tls'.format(CLUSTERDOCK_CLIENT_CONTAINER_DIR)
 TLS_CLIENT_DIR = '{}/client'.format(TLS_DIR)
 
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
 logger = logging.getLogger('clusterdock.{}'.format(__name__))
 
 
@@ -169,7 +171,6 @@ def main(args):
     if args.tls:
         setup_commands = [
             'mkdir -p {}'.format(TLS_CLIENT_DIR),
-            'wget -P {} {}'.format(TLS_DIR, TLS_CONF_URL),
             'mkdir -p {dir}/certs {dir}/crl {dir}/newcerts {dir}/private'.format(dir=TLS_DIR),
             'chmod 700 {}/private'.format(TLS_DIR),
             'touch {}/index.txt'.format(TLS_DIR),
@@ -177,6 +178,9 @@ def main(args):
             'echo 1000 > {}/serial'.format(TLS_DIR),
         ]
         execute_node_command(proxy_node, ' && '.join(setup_commands), quiet, 'TLS system setup failed')
+
+        with open(os.path.join(CURRENT_DIR, 'resources/openssl.cnf')) as f:
+            proxy_node.put_file('{}/openssl.cnf'.format(TLS_DIR), f.read())
 
         ca_auth_commands = [
             'export CA_HOME={}'.format(TLS_DIR),


### PR DESCRIPTION
A few months ago the openssl.cnf file was moved from the [pulsar](https://github.com/apache/pulsar) repository to the [pulsar-site](https://github.com/apache/pulsar-site) repository. That change caused an error when trying to start a pulsar cluster with TLS. At that time I made a [PR](https://github.com/clusterdock/topology_apache_pulsar/pull/9) to point to the new location of this file. However, it looks like they have removed that file from their repository.

In order to avoid this being a problem again in the future, I have considered that the best option is to add directly this file to the repository. But if you prefer not to, we can use this url: `https://raw.githubusercontent.com/apache/pulsar/v2.9.3/site2/website/static/examples/openssl.cnf`